### PR TITLE
Removed space-padding after colon in stomp frame headers

### DIFF
--- a/library/ZendQueue/Stomp/Frame.php
+++ b/library/ZendQueue/Stomp/Frame.php
@@ -259,7 +259,7 @@ class Frame implements StompFrame
 
         // Headers
         foreach ($headers as $key=>$value) {
-            $frame .= $key . ': ' . $value . self::EOL;
+            $frame .= $key . ':' . $value . self::EOL;
         }
 
         // Seperator


### PR DESCRIPTION
"In STOMP 1.1, clients and servers MUST never trim or pad headers with spaces."
(http://stomp.github.com/stomp-specification-1.1.html)

With the forced space at the beginning of the header value, servers implementing the STOMP 1.1 standard getting wrong values and won't work as expected.

Change-Id: I19baa27d472c9413d0fb522fb5a7c4625b0fb3e0
