### PR TITLE
Added dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,12 @@
             "url": "http://packages.zendframework.com/"
         }
     ],
+    "require-dev": {
+        "zendframework/zend-config": "2.0.*",
+        "zendframework/zend-db": "2.0.*",
+        "zendframework/zend-json": "2.0.*",
+        "zendframework/zend-stdlib": "2.0.*"
+    },
     "require": {
         "php": ">=5.3.3"
     },


### PR DESCRIPTION
Dependencies can be added with the --dev parameter at composer install.
If the constants will be ported to this project, there are no dependencies outside of composer (and everyone can run the unit tests if needed)

Change-Id: Idd114c069f3298c94ca88774faf1baa5dcee0d4c
